### PR TITLE
Initialize Node.js shiller bot

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+BOT_MODE=TEST

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
-# Shiller
-Shiller
+# shiller-bot
+
+Este proyecto es un bot en Node.js diseñado para automatizar mensajes virales sobre tokens cripto mediante publicaciones programadas. Utiliza frases cargadas desde `shillMessages.json` y combina palabras clave definidas en `config.json` y en el escáner de tendencias para simular actividad promocional.
+
+Para iniciar el bot:
+
+```bash
+node index.js
+```
+
+El bot comenzará a mostrar en consola mensajes de shill a intervalos aleatorios.

--- a/config.json
+++ b/config.json
@@ -1,0 +1,4 @@
+{
+  "defaultInterval": 60,
+  "keywords": ["ape", "moonshot", "hodl"]
+}

--- a/index.js
+++ b/index.js
@@ -1,0 +1,11 @@
+require('dotenv').config();
+const postScheduler = require('./postScheduler');
+const config = require('./config.json');
+
+function startBot() {
+  console.log(`Modo del bot: ${process.env.BOT_MODE}`);
+  postScheduler.startShilling(config.defaultInterval);
+  console.log('✅ Shiller Bot listo para causar caos.');
+}
+
+startBot();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "shiller-bot",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "dotenv": "^17.0.1"
+  }
+}

--- a/postScheduler.js
+++ b/postScheduler.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const config = require('./config.json');
+const { getTrendingKeywords } = require('./trendScanner');
+
+let messages = [];
+try {
+  const raw = fs.readFileSync('./shillMessages.json', 'utf8');
+  messages = JSON.parse(raw);
+} catch (err) {
+  console.error('Error loading shill messages:', err);
+}
+
+function getRandomItem(arr) {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+function buildMessage() {
+  const template = getRandomItem(messages) || 'Buy {keyword} now!';
+  const keywords = config.keywords.concat(getTrendingKeywords());
+  const keyword = getRandomItem(keywords);
+  return template.replace('{keyword}', keyword);
+}
+
+function startShilling(interval = config.defaultInterval) {
+  const scheduleNext = () => {
+    const randomOffset = Math.random() * interval * 1000;
+    const delay = interval * 1000 + randomOffset;
+    setTimeout(() => {
+      const message = buildMessage();
+      console.log(`\u{1F525} Shilling: ${message}`);
+      scheduleNext();
+    }, delay);
+  };
+  scheduleNext();
+}
+
+module.exports = { startShilling };

--- a/shillMessages.json
+++ b/shillMessages.json
@@ -1,0 +1,5 @@
+[
+  "Don't miss out on {keyword}!",
+  "{keyword} is going to the moon!",
+  "Get in on {keyword} before it's too late!"
+]

--- a/trendScanner.js
+++ b/trendScanner.js
@@ -1,0 +1,5 @@
+function getTrendingKeywords() {
+  return ['pump', 'moon', 'degen'];
+}
+
+module.exports = { getTrendingKeywords };


### PR DESCRIPTION
## Summary
- replace Python skeleton with Node.js project
- add post scheduler and trend scanner modules
- configure environment and keywords for posting

## Testing
- `node index.js` (shows start-up message)

------
https://chatgpt.com/codex/tasks/task_e_6866f3df1fa88328a34c0f093ed1b069