### PR TITLE
Add Python shiller message generator

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+BOT_MODE=TEST

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
-# Shiller
-Shiller
+# shiller-bot
+
+Este proyecto es un bot en Node.js diseñado para automatizar mensajes virales sobre tokens cripto mediante publicaciones programadas. Utiliza frases cargadas desde `shillMessages.json` y combina palabras clave definidas en `config.json` y en el escáner de tendencias para simular actividad promocional.
+
+Para iniciar el bot:
+
+```bash
+node index.js
+```
+
+El bot comenzará a mostrar en consola mensajes de shill a intervalos aleatorios.

--- a/config.json
+++ b/config.json
@@ -1,0 +1,4 @@
+{
+  "defaultInterval": 60,
+  "keywords": ["ape", "moonshot", "hodl"]
+}

--- a/index.js
+++ b/index.js
@@ -1,0 +1,11 @@
+require('dotenv').config();
+const postScheduler = require('./postScheduler');
+const config = require('./config.json');
+
+function startBot() {
+  console.log(`Modo del bot: ${process.env.BOT_MODE}`);
+  postScheduler.startShilling(config.defaultInterval);
+  console.log('✅ Shiller Bot listo para causar caos.');
+}
+
+startBot();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "shiller-bot",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "dotenv": "^17.0.1"
+  }
+}

--- a/postScheduler.js
+++ b/postScheduler.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const config = require('./config.json');
+const { getTrendingKeywords } = require('./trendScanner');
+
+let messages = [];
+try {
+  const raw = fs.readFileSync('./shillMessages.json', 'utf8');
+  messages = JSON.parse(raw);
+} catch (err) {
+  console.error('Error loading shill messages:', err);
+}
+
+function getRandomItem(arr) {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+function buildMessage() {
+  const template = getRandomItem(messages) || 'Buy {keyword} now!';
+  const keywords = config.keywords.concat(getTrendingKeywords());
+  const keyword = getRandomItem(keywords);
+  return template.replace('{keyword}', keyword);
+}
+
+function startShilling(interval = config.defaultInterval) {
+  const scheduleNext = () => {
+    const randomOffset = Math.random() * interval * 1000;
+    const delay = interval * 1000 + randomOffset;
+    setTimeout(() => {
+      const message = buildMessage();
+      console.log(`\u{1F525} Shilling: ${message}`);
+      scheduleNext();
+    }, delay);
+  };
+  scheduleNext();
+}
+
+module.exports = { startShilling };

--- a/shillMessages.json
+++ b/shillMessages.json
@@ -1,0 +1,5 @@
+[
+  "Don't miss out on {keyword}!",
+  "{keyword} is going to the moon!",
+  "Get in on {keyword} before it's too late!"
+]

--- a/shiller_bot/main.py
+++ b/shiller_bot/main.py
@@ -1,0 +1,13 @@
+from message_generator import generate_shill_message
+from poster import post_to_console, post_random
+
+
+def main():
+    topic = input("\u00bfTema del shill? ")
+    message = generate_shill_message(topic)
+    post_to_console(message)
+    post_random(message)
+
+
+if __name__ == "__main__":
+    main()

--- a/shiller_bot/message_generator.py
+++ b/shiller_bot/message_generator.py
@@ -1,0 +1,21 @@
+import random
+
+phrases = [
+    "BUY THE DIP",
+    "BOMBUCKS IS THE FUTURE",
+    "HODL STRONG",
+    "TO THE MOON",
+    "100x INCOMING"
+]
+
+templates = [
+    "{phrase}! {topic} is about to explode!",
+    "Get in on {topic} now - {phrase}!",
+    "{topic} is the next big thing. {phrase}!",
+    "Don't miss {topic}! {phrase}!"
+]
+
+def generate_shill_message(topic: str) -> str:
+    phrase = random.choice(phrases)
+    template = random.choice(templates)
+    return template.format(topic=topic, phrase=phrase)

--- a/shiller_bot/poster.py
+++ b/shiller_bot/poster.py
@@ -1,0 +1,33 @@
+import random
+
+try:
+    from colorama import init, Fore, Style
+    init(autoreset=True)
+    COLOR = True
+except Exception:
+    COLOR = False
+
+
+def _color(text: str) -> str:
+    if COLOR:
+        return f"{Fore.CYAN}{text}{Style.RESET_ALL}"
+    return text
+
+
+def post_to_console(message: str) -> None:
+    print(_color(f">> {message}"))
+
+
+def simulate_post_to_x(message: str) -> None:
+    print(_color(f"[X] {message}"))
+
+
+def simulate_post_to_telegram(message: str) -> None:
+    print(_color(f"[Telegram] {message}"))
+
+
+ALL_POSTERS = [simulate_post_to_x, simulate_post_to_telegram]
+
+
+def post_random(message: str) -> None:
+    random.choice(ALL_POSTERS)(message)

--- a/trendScanner.js
+++ b/trendScanner.js
@@ -1,0 +1,5 @@
+function getTrendingKeywords() {
+  return ['pump', 'moon', 'degen'];
+}
+
+module.exports = { getTrendingKeywords };


### PR DESCRIPTION
## Summary
- implement simple message generator with random templates
- add poster utilities including colorized console output
- create a minimal main script to interactively generate and post messages

## Testing
- `python3 shiller_bot/main.py <<EOF
Pump.fun
EOF`
- `npm install`
- `node index.js` (started bot)

------
https://chatgpt.com/codex/tasks/task_e_6866f3df1fa88328a34c0f093ed1b069